### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,19 @@ keywords = [
 async-trait = { version = "^0.1.52", optional = true }
 base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.1.0", features = ["serde"], optional = true }
-crypto-common = "^0.1.0"
+crypto-common = { version = "^0.1.1", optional = true }
 hmac = { version = "^0.12.0", features = ["std"], optional = true }
 hyper = { version = "^0.14.16", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 log = { version = "^0.4.14", optional = true }
 prometheus = { version = "^0.13.0", optional = true }
-serde = { version = "^1.0.131", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.72", features = [
+serde = { version = "^1.0.133", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.74", features = [
     "preserve_order",
     "float_roundtrip",
 ], optional = true }
-sha2 = { version = "^0.10.0", optional = true }
+sha2 = { version = "^0.10.1", optional = true }
 thiserror = { version = "^1.0.30", optional = true }
 tracing = { version = "^0.1.29", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
@@ -47,6 +47,7 @@ client = [
     "async-trait",
     "base64",
     "bytes",
+    "crypto-common",
     "hmac",
     "hyper",
     "hyper/client",


### PR DESCRIPTION
* Bump cryto-common to 0.1.1 and set it optional
* Bump serde to 1.0.133
* Bump serde_json to 1.0.74
* Bump sha2 to 0.10.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>