### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ async-trait = { version = "^0.1.52", optional = true }
 base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.1.0", features = ["serde"], optional = true }
 cidr = { version = "*", optional = true }
-crypto-common = { version = "^0.1.1", optional = true }
+crypto-common = { version = "^0.1.2", optional = true }
 headers = { version = "^0.3.6", optional = true }
 hmac = { version = "^0.12.0", features = ["std"], optional = true }
-hyper = { version = "^0.14.16", default-features = false, optional = true }
+hyper = { version = "^0.14.17", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }


### PR DESCRIPTION
* Bump crypto-commons to 0.1.2
* Bump hyper to 0.14.17

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>