### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { version = "^0.1.52", optional = true }
+async-trait = { version = "^0.1.53", optional = true }
 base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.1.0", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
 crypto-common = { version = "^0.1.3", optional = true }
 headers = { version = "^0.3.7", optional = true }
 hmac = { version = "^0.12.1", features = ["std"], optional = true }
-hyper = { version = "^0.14.17", default-features = false, optional = true }
+hyper = { version = "^0.14.18", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }


### PR DESCRIPTION
* Bump async-trait to 0.1.53
* Bump hyper to 0.14.18

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>