### PR TITLE
Update tracing and log dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hyper = { version = "^0.14.18", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
-log = { version = "^0.4.14", optional = true }
+log = { version = "^0.4.16", optional = true }
 prometheus = { version = "^0.13.0", optional = true }
 serde = { version = "^1.0.136", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.79", features = [
@@ -39,7 +39,7 @@ serde_json = { version = "^1.0.79", features = [
 ], optional = true }
 sha2 = { version = "^0.10.2", optional = true }
 thiserror = { version = "^1.0.30", optional = true }
-tracing = { version = "^0.1.31", optional = true }
+tracing = { version = "^0.1.32", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }
 urlencoding = { version = "^2.1.0", optional = true }


### PR DESCRIPTION
* Bump log to 0.4.16
* Bump tracing to 0.1.32

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>