### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ hyper = { version = "^0.14.18", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
-log = { version = "^0.4.16", optional = true }
+log = { version = "^0.4.17", optional = true }
 prometheus = { version = "^0.13.0", optional = true }
-serde = { version = "^1.0.136", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.79", features = [
+serde = { version = "^1.0.137", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.81", features = [
     "preserve_order",
     "float_roundtrip",
 ], optional = true }
 sha2 = { version = "^0.10.2", optional = true }
-thiserror = { version = "^1.0.30", optional = true }
+thiserror = { version = "^1.0.31", optional = true }
 tracing = { version = "^0.1.34", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }


### PR DESCRIPTION
* Bump log to 0.4.17
* Bump serde to 1.0.137
* Bump serde_json to 1.0.81
* Bump thiserror to 1.0.31

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>