### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cidr = { version = "^0.2.1", optional = true }
 crypto-common = { version = "^0.1.3", optional = true }
 headers = { version = "^0.3.7", optional = true }
 hmac = { version = "^0.12.1", features = ["std"], optional = true }
-hyper = { version = "^0.14.18", default-features = false, optional = true }
+hyper = { version = "^0.14.19", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
@@ -43,7 +43,7 @@ tracing = { version = "^0.1.34", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }
 urlencoding = { version = "^2.1.0", optional = true }
-uuid = { version = "^1.1.0", features = ["serde", "v4"], optional = true }
+uuid = { version = "^1.1.1", features = ["serde", "v4"], optional = true }
 
 [features]
 default = ["client", "proxy", "logging"]


### PR DESCRIPTION
* Bump hyper to 0.14.19
* Bump uuid to 1.1.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>