### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { version = "^0.1.53", optional = true }
+async-trait = { version = "^0.1.56", optional = true }
 base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.1.0", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
@@ -39,11 +39,11 @@ serde_json = { version = "^1.0.81", features = [
 ], optional = true }
 sha2 = { version = "^0.10.2", optional = true }
 thiserror = { version = "^1.0.31", optional = true }
-tracing = { version = "^0.1.34", optional = true }
+tracing = { version = "^0.1.35", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }
 urlencoding = { version = "^2.1.0", optional = true }
-uuid = { version = "^1.1.1", features = ["serde", "v4"], optional = true }
+uuid = { version = "^1.1.2", features = ["serde", "v4"], optional = true }
 
 [features]
 default = ["client", "proxy", "logging"]


### PR DESCRIPTION
* Bump async-trait to 0.1.56
* Bump tracing to 0.1.35
* Bump uuid to 1.1.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>