### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ async-trait = { version = "^0.1.56", optional = true }
 base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.1.0", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
-crypto-common = { version = "^0.1.3", optional = true }
+crypto-common = { version = "^0.1.6", optional = true }
 headers = { version = "^0.3.7", optional = true }
 hmac = { version = "^0.12.1", features = ["std"], optional = true }
-hyper = { version = "^0.14.19", default-features = false, optional = true }
+hyper = { version = "^0.14.20", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 log = { version = "^0.4.17", optional = true }
 prometheus = { version = "^0.13.1", optional = true }
-serde = { version = "^1.0.137", features = ["derive"], optional = true }
+serde = { version = "^1.0.139", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.82", features = [
     "preserve_order",
     "float_roundtrip",


### PR DESCRIPTION
* Bump crypto-common to 0.1.6
* Bump hyper to 0.14.20
* Bump serde to 1.0.139

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>