### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { version = "^0.1.56", optional = true }
+async-trait = { version = "^0.1.57", optional = true }
 base64 = { version = "^0.13.0", optional = true }
-bytes = { version = "^1.1.0", features = ["serde"], optional = true }
+bytes = { version = "^1.2.1", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
 crypto-common = { version = "^0.1.6", optional = true }
 headers = { version = "^0.3.7", optional = true }
@@ -32,14 +32,14 @@ hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"]
 lazy_static = { version = "^1.4.0", optional = true }
 log = { version = "^0.4.17", optional = true }
 prometheus = { version = "^0.13.1", optional = true }
-serde = { version = "^1.0.139", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.82", features = [
+serde = { version = "^1.0.143", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.83", features = [
     "preserve_order",
     "float_roundtrip",
 ], optional = true }
 sha2 = { version = "^0.10.2", optional = true }
-thiserror = { version = "^1.0.31", optional = true }
-tracing = { version = "^0.1.35", optional = true }
+thiserror = { version = "^1.0.32", optional = true }
+tracing = { version = "^0.1.36", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }
 urlencoding = { version = "^2.1.0", optional = true }


### PR DESCRIPTION
* Bump async-trait to 0.1.57
* Bump bytes to 1.2.1
* Bump serde to 1.0.143
* Bump serde_json to 1.0.83
* Bump thiserror to 1.0.32
* Bump tracing to 0.1.36

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>