### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,25 +24,25 @@ base64 = { version = "^0.13.0", optional = true }
 bytes = { version = "^1.2.1", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
 crypto-common = { version = "^0.1.6", optional = true }
-headers = { version = "^0.3.7", optional = true }
+headers = { version = "^0.3.8", optional = true }
 hmac = { version = "^0.12.1", features = ["std"], optional = true }
 hyper = { version = "^0.14.20", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 log = { version = "^0.4.17", optional = true }
-prometheus = { version = "^0.13.1", optional = true }
-serde = { version = "^1.0.143", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.83", features = [
+prometheus = { version = "^0.13.2", optional = true }
+serde = { version = "^1.0.144", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.85", features = [
     "preserve_order",
     "float_roundtrip",
 ], optional = true }
-sha2 = { version = "^0.10.2", optional = true }
-thiserror = { version = "^1.0.32", optional = true }
+sha2 = { version = "^0.10.5", optional = true }
+thiserror = { version = "^1.0.34", optional = true }
 tracing = { version = "^0.1.36", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
-url = { version = "^2.2.2", default-features = false, features = ["serde"], optional = true }
-urlencoding = { version = "^2.1.0", optional = true }
+url = { version = "^2.3.1", default-features = false, features = ["serde"], optional = true }
+urlencoding = { version = "^2.1.2", optional = true }
 uuid = { version = "^1.1.2", features = ["serde", "v4"], optional = true }
 
 [features]


### PR DESCRIPTION
* Bump headers to 0.3.8
* Bump prometheus to 0.13.2
* Bump serde to 1.0.144
* Bump serde_json to 10.85
* Bump sha2 to 0.10.5
* Bump thiserror to 1.0.34
* Bump url to 2.3.1
* Bump urlencoding to 2.1.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>