### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { version = "^0.1.57", optional = true }
-base64 = { version = "^0.13.0", optional = true }
+async-trait = { version = "^0.1.58", optional = true }
+base64 = { version = "^0.13.1", optional = true }
 bytes = { version = "^1.2.1", features = ["serde"], optional = true }
 cidr = { version = "^0.2.1", optional = true }
 crypto-common = { version = "^0.1.6", optional = true }
 headers = { version = "^0.3.8", optional = true }
 hmac = { version = "^0.12.1", features = ["std"], optional = true }
-hyper = { version = "^0.14.20", default-features = false, optional = true }
+hyper = { version = "^0.14.22", default-features = false, optional = true }
 hyper-tls = { version = "^0.5.0", optional = true }
 hyper-proxy = { version = "^0.9.1", default-features = false, features = ["tls"], optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 log = { version = "^0.4.17", optional = true }
-prometheus = { version = "^0.13.2", optional = true }
-serde = { version = "^1.0.145", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.85", features = [
+prometheus = { version = "^0.13.3", optional = true }
+serde = { version = "^1.0.147", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.87", features = [
     "preserve_order",
     "float_roundtrip",
 ], optional = true }
@@ -43,7 +43,7 @@ tracing = { version = "^0.1.37", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 url = { version = "^2.3.1", default-features = false, features = ["serde"], optional = true }
 urlencoding = { version = "^2.1.2", optional = true }
-uuid = { version = "^1.1.2", features = ["serde", "v4"], optional = true }
+uuid = { version = "^1.2.1", features = ["serde", "v4"], optional = true }
 
 [features]
 default = ["client", "proxy", "logging"]


### PR DESCRIPTION
* Bump async-trait to 0.1.58
* Bump base64 to 0.13.1
* Bump hyper to 0.14.22
* Bump prometheus to 0.13.3
* Bump serde to 1.0.147
* Bump serde_json to 1.0.87
* Bump uuid to 1.2.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>